### PR TITLE
Fix operators when array of .in([]) is empty

### DIFF
--- a/lib/condition/index.ts
+++ b/lib/condition/index.ts
@@ -48,6 +48,10 @@ export default class Condition<E extends typeof Entity> {
         return this;
       },
       in: (values: Array<EntityValue<E, K>>): C => {
+        if (values.length === 0) {
+          return this;
+        }
+
         const processedValues = values.map((value) => transformValue(this.entity, key, value));
         this.operators.push(...OPERATORS.in(key, processedValues));
         return this;
@@ -115,6 +119,10 @@ export default class Condition<E extends typeof Entity> {
           return this;
         },
         in: (values: Array<EntityValue<E, K>>): C => {
+          if (values.length === 0) {
+            return this;
+          }
+
           const processedValues = values.map((value) => transformValue(this.entity, key, value));
           this.operators.push(...OPERATORS.notIn(key, processedValues));
           return this;

--- a/tests/unit/condition/index.test.ts
+++ b/tests/unit/condition/index.test.ts
@@ -130,6 +130,12 @@ describe('Condition', () => {
       });
 
       describe('in', () => {
+        test('Should not push in expression for en empty array', async () => {
+          condition.attribute('partitionKey').in([]);
+
+          expect(condition['operators']).toEqual([]);
+        });
+
         test('Should push in expression', async () => {
           condition.attribute('partitionKey').in(['value1', 'value2']);
 
@@ -304,6 +310,12 @@ describe('Condition', () => {
         });
 
         describe('in', () => {
+          test('Should not push in expression for en empty array', async () => {
+            condition.attribute('partitionKey').not().in([]);
+
+            expect(condition['operators']).toEqual([]);
+          });
+
           test('Should push in expression', async () => {
             condition.attribute('partitionKey').not().in(['value1', 'value2']);
 


### PR DESCRIPTION
### Summary:
<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:

Fixes https://github.com/blazejkustra/dynamode/issues/16

### Type of change:
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Something not listed here


### Is this a breaking change?
- [ ] YES 🚨
- [x] No

### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamode documentation (if required)
- [x] I have added/updated the Dynamode test cases (if required) 
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamode License](../LICENSE).
