### PR TITLE
Fix for `startAt fails when querying secondary indices`

### DIFF
--- a/lib/entity/helpers/converters.ts
+++ b/lib/entity/helpers/converters.ts
@@ -74,15 +74,19 @@ export function convertAttributeValuesToLastKey<M extends Metadata<E>, E extends
 
 export function convertPrimaryKeyToAttributeValues<M extends Metadata<E>, E extends typeof Entity>(
   entity: E,
-  primaryKey: TablePrimaryKey<M, E>,
+  primaryKey: TableRetrieverLastKey<M, E> | TablePrimaryKey<M, E>,
 ): AttributeValues {
   const dynamoObject: GenericObject = {};
   const { partitionKey, sortKey } = Dynamode.storage.getEntityMetadata(entity.name);
 
-  dynamoObject[partitionKey] = transformValue(entity, partitionKey, (<any>primaryKey)[partitionKey]);
+  dynamoObject[partitionKey] = transformValue(
+    entity,
+    partitionKey,
+    primaryKey[partitionKey as keyof typeof primaryKey],
+  );
 
   if (sortKey) {
-    dynamoObject[sortKey] = transformValue(entity, sortKey, (<any>primaryKey)[sortKey]);
+    dynamoObject[sortKey] = transformValue(entity, sortKey, primaryKey[sortKey as keyof typeof primaryKey]);
   }
 
   return objectToDynamo(dynamoObject);

--- a/lib/query/index.ts
+++ b/lib/query/index.ts
@@ -1,7 +1,7 @@
 import { QueryCommandOutput, QueryInput } from '@aws-sdk/client-dynamodb';
 import Dynamode from '@lib/dynamode/index';
 import Entity from '@lib/entity';
-import { convertAttributeValuesToEntity, convertAttributeValuesToPrimaryKey } from '@lib/entity/helpers/converters';
+import { convertAttributeValuesToEntity, convertAttributeValuesToLastKey } from '@lib/entity/helpers/converters';
 import { EntityKey, EntityValue } from '@lib/entity/types';
 import type { QueryRunOptions, QueryRunOutput } from '@lib/query/types';
 import RetrieverBase from '@lib/retriever';
@@ -16,10 +16,10 @@ export default class Query<M extends Metadata<E>, E extends typeof Entity> exten
     super(entity);
   }
 
-  public run(options?: QueryRunOptions & { return?: 'default' }): Promise<QueryRunOutput<E>>;
+  public run(options?: QueryRunOptions & { return?: 'default' }): Promise<QueryRunOutput<M, E>>;
   public run(options: QueryRunOptions & { return: 'output' }): Promise<QueryCommandOutput>;
   public run(options: QueryRunOptions & { return: 'input' }): QueryInput;
-  public run(options?: QueryRunOptions): Promise<QueryRunOutput<E> | QueryCommandOutput> | QueryInput {
+  public run(options?: QueryRunOptions): Promise<QueryRunOutput<M, E> | QueryCommandOutput> | QueryInput {
     this.buildQueryInput(options?.extraInput);
 
     if (options?.return === 'input') {
@@ -57,7 +57,7 @@ export default class Query<M extends Metadata<E>, E extends typeof Entity> exten
 
       return {
         items: items.map((item) => convertAttributeValuesToEntity(this.entity, item)),
-        lastKey: lastKey && convertAttributeValuesToPrimaryKey(this.entity, lastKey),
+        lastKey: lastKey && convertAttributeValuesToLastKey(this.entity, lastKey),
         count,
         scannedCount,
       };

--- a/lib/query/types.ts
+++ b/lib/query/types.ts
@@ -1,7 +1,8 @@
 import { QueryInput } from '@aws-sdk/client-dynamodb';
 import Entity from '@lib/entity';
 import type { ReturnOption } from '@lib/entity/types';
-import { AttributeNames, AttributeValues, GenericObject } from '@lib/utils';
+import { Metadata, TableRetrieverLastKey } from '@lib/table/types';
+import { AttributeNames, AttributeValues } from '@lib/utils';
 
 export type QueryRunOptions = {
   extraInput?: Partial<QueryInput>;
@@ -11,11 +12,11 @@ export type QueryRunOptions = {
   max?: number;
 };
 
-export type QueryRunOutput<E extends typeof Entity> = {
+export type QueryRunOutput<M extends Metadata<E>, E extends typeof Entity> = {
   items: Array<InstanceType<E>>;
   count: number;
   scannedCount: number;
-  lastKey?: GenericObject;
+  lastKey?: TableRetrieverLastKey<M, E>;
 };
 
 export type BuildQueryConditionExpression = {

--- a/lib/retriever/index.ts
+++ b/lib/retriever/index.ts
@@ -3,9 +3,9 @@ import Condition from '@lib/condition';
 import Dynamode from '@lib/dynamode/index';
 import Entity from '@lib/entity';
 import { buildGetProjectionExpression } from '@lib/entity/helpers/buildExpressions';
-import { convertPrimaryKeyToAttributeValues } from '@lib/entity/helpers/converters';
+import { convertRetrieverLastKeyToAttributeValues } from '@lib/entity/helpers/converters';
 import { EntityKey } from '@lib/entity/types';
-import { Metadata, TablePrimaryKey } from '@lib/table/types';
+import { Metadata, TableRetrieverLastKey } from '@lib/table/types';
 import { AttributeNames, AttributeValues } from '@lib/utils';
 
 export default class RetrieverBase<M extends Metadata<E>, E extends typeof Entity> extends Condition<E> {
@@ -25,9 +25,9 @@ export default class RetrieverBase<M extends Metadata<E>, E extends typeof Entit
     return this;
   }
 
-  public startAt(key?: TablePrimaryKey<M, E>) {
+  public startAt(key?: TableRetrieverLastKey<M, E>) {
     if (key) {
-      this.input.ExclusiveStartKey = convertPrimaryKeyToAttributeValues(this.entity, key);
+      this.input.ExclusiveStartKey = convertRetrieverLastKeyToAttributeValues(this.entity, key);
     }
 
     return this;

--- a/lib/scan/index.ts
+++ b/lib/scan/index.ts
@@ -1,7 +1,7 @@
 import { ScanCommandOutput, ScanInput } from '@aws-sdk/client-dynamodb';
 import Dynamode from '@lib/dynamode/index';
 import Entity from '@lib/entity';
-import { convertAttributeValuesToEntity, convertAttributeValuesToPrimaryKey } from '@lib/entity/helpers/converters';
+import { convertAttributeValuesToEntity, convertAttributeValuesToLastKey } from '@lib/entity/helpers/converters';
 import RetrieverBase from '@lib/retriever';
 import type { ScanRunOptions, ScanRunOutput } from '@lib/scan/types';
 import { Metadata, TableIndexNames } from '@lib/table/types';
@@ -14,10 +14,10 @@ export default class Scan<M extends Metadata<E>, E extends typeof Entity> extend
     super(entity);
   }
 
-  public run(options?: ScanRunOptions & { return?: 'default' }): Promise<ScanRunOutput<E>>;
+  public run(options?: ScanRunOptions & { return?: 'default' }): Promise<ScanRunOutput<M, E>>;
   public run(options: ScanRunOptions & { return: 'output' }): Promise<ScanCommandOutput>;
   public run(options: ScanRunOptions & { return: 'input' }): ScanInput;
-  public run(options?: ScanRunOptions): Promise<ScanRunOutput<E> | ScanCommandOutput> | ScanInput {
+  public run(options?: ScanRunOptions): Promise<ScanRunOutput<M, E> | ScanCommandOutput> | ScanInput {
     this.buildScanInput(options?.extraInput);
 
     if (options?.return === 'input') {
@@ -38,7 +38,7 @@ export default class Scan<M extends Metadata<E>, E extends typeof Entity> extend
         count: result.Count || 0,
         scannedCount: result.ScannedCount || 0,
         lastKey: result.LastEvaluatedKey
-          ? convertAttributeValuesToPrimaryKey(this.entity, result.LastEvaluatedKey)
+          ? convertAttributeValuesToLastKey(this.entity, result.LastEvaluatedKey)
           : undefined,
       };
     })();

--- a/lib/scan/types.ts
+++ b/lib/scan/types.ts
@@ -1,18 +1,19 @@
 import { ScanInput } from '@aws-sdk/client-dynamodb';
 import Entity from '@lib/entity';
 import type { ReturnOption } from '@lib/entity/types';
-import { AttributeNames, AttributeValues, GenericObject } from '@lib/utils';
+import { Metadata, TableRetrieverLastKey } from '@lib/table/types';
+import { AttributeNames, AttributeValues } from '@lib/utils';
 
 export type ScanRunOptions = {
   extraInput?: Partial<ScanInput>;
   return?: ReturnOption;
 };
 
-export type ScanRunOutput<E extends typeof Entity> = {
+export type ScanRunOutput<M extends Metadata<E>, E extends typeof Entity> = {
   items: Array<InstanceType<E>>;
   count: number;
   scannedCount: number;
-  lastKey?: GenericObject;
+  lastKey?: TableRetrieverLastKey<M, E>;
 };
 
 export type BuildScanConditionExpression = {

--- a/lib/table/types.ts
+++ b/lib/table/types.ts
@@ -40,6 +40,11 @@ export type TablePrimaryKey<M extends Metadata<E>, E extends typeof Entity> = Pi
   Extract<EntityKey<E>, SK<M, E> extends string ? PK<M, E> | SK<M, E> : PK<M, E>>
 >;
 
+export type TableRetrieverLastKey<M extends Metadata<E>, E extends typeof Entity> = Pick<
+  InstanceType<E>,
+  Extract<EntityKey<E>, TablePartitionKeys<M, E> | TableSortKeys<M, E>>
+>;
+
 export type TableIndexNames<M extends Metadata<E>, E extends typeof Entity> = keyof Idx<M, E> extends string
   ? keyof Idx<M, E>
   : never;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.0.0",
+      "version": "1.0.1-rc.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.474.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.0",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/e2e/entity/query.test.ts
+++ b/tests/e2e/entity/query.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { MockEntityManager, TEST_TABLE_NAME, TestTableManager } from '../../fixtures';
+import { mockEntityFactory } from '../mockEntityFactory';
+
+describe('EntityManager.query', () => {
+  beforeAll(async () => {
+    vi.useFakeTimers();
+    await TestTableManager.createTable();
+  });
+
+  afterAll(async () => {
+    await TestTableManager.deleteTable(TEST_TABLE_NAME);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe.sequential('MockEntityManager', () => {
+    test('Should be able to retrieve an item', async () => {
+      // Arrange
+      const mock = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK1' });
+      await MockEntityManager.put(mock);
+
+      // Act
+      const mockEntityRetrieved = await MockEntityManager.query()
+        .partitionKey('partitionKey')
+        .eq('PK1')
+        .sortKey('sortKey')
+        .eq('SK1')
+        .run();
+      const mockEntityRetrieved2 = await MockEntityManager.query()
+        .partitionKey('partitionKey')
+        .eq('PK1')
+        .sortKey('sortKey')
+        .beginsWith('SK')
+        .run();
+      const mockEntityRetrieved3 = await MockEntityManager.query().partitionKey('partitionKey').eq('PK1').run();
+
+      // Assert
+      expect(mockEntityRetrieved.items[0]).toEqual(mock);
+      expect(mockEntityRetrieved2.items[0]).toEqual(mock);
+      expect(mockEntityRetrieved3.items[0]).toEqual(mock);
+
+      expect(mockEntityRetrieved.count).toEqual(1);
+      expect(mockEntityRetrieved2.count).toEqual(1);
+      expect(mockEntityRetrieved3.count).toEqual(1);
+    });
+
+    test('Should be able to retrieve multiple items', async () => {
+      // Arrange
+      const mock = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK1' });
+      const mock2 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK2' });
+      const mock3 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK3' });
+      await MockEntityManager.put(mock);
+      await MockEntityManager.put(mock2);
+      await MockEntityManager.put(mock3);
+
+      // Act
+      const mockEntityRetrieved = await MockEntityManager.query()
+        .partitionKey('partitionKey')
+        .eq('PK1')
+        .sortKey('sortKey')
+        .eq('SK1')
+        .run();
+      const mockEntityRetrieved2 = await MockEntityManager.query()
+        .partitionKey('partitionKey')
+        .eq('PK1')
+        .sortKey('sortKey')
+        .beginsWith('SK')
+        .run();
+      const mockEntityRetrieved3 = await MockEntityManager.query()
+        .partitionKey('partitionKey')
+        .eq('PK1')
+        .limit(2)
+        .run();
+
+      // Assert
+      expect(mockEntityRetrieved.items[0]).toEqual(mock);
+      expect(mockEntityRetrieved2.items[0]).toEqual(mock);
+      expect(mockEntityRetrieved2.items[1]).toEqual(mock2);
+      expect(mockEntityRetrieved2.items[2]).toEqual(mock3);
+      expect(mockEntityRetrieved3.items[0]).toEqual(mock);
+
+      expect(mockEntityRetrieved.count).toEqual(1);
+      expect(mockEntityRetrieved2.count).toEqual(3);
+      expect(mockEntityRetrieved3.count).toEqual(2);
+
+      expect(mockEntityRetrieved.lastKey).toEqual(undefined);
+      expect(mockEntityRetrieved2.lastKey).toEqual(undefined);
+      expect(mockEntityRetrieved3.lastKey).toEqual({ partitionKey: 'PK1', sortKey: 'SK2' });
+    });
+
+    test('Should be able to retrieve multiple items with pagination (on primary key)', async () => {
+      // Arrange
+      const mock = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK1' });
+      const mock2 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK2' });
+      const mock3 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK3' });
+      const mock4 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK4' });
+      await MockEntityManager.put(mock);
+      await MockEntityManager.put(mock2);
+      await MockEntityManager.put(mock3);
+      await MockEntityManager.put(mock4);
+
+      // Act
+      const mockEntityRetrieved = await MockEntityManager.query().partitionKey('partitionKey').eq('PK1').limit(2).run();
+      const mockEntityRetrieved2 = await MockEntityManager.query()
+        .partitionKey('partitionKey')
+        .eq('PK1')
+        .startAt(mockEntityRetrieved?.lastKey)
+        .run();
+
+      // Assert
+      expect(mockEntityRetrieved.items[0]).toEqual(mock);
+      expect(mockEntityRetrieved.items[1]).toEqual(mock2);
+      expect(mockEntityRetrieved2.items[0]).toEqual(mock3);
+      expect(mockEntityRetrieved2.items[1]).toEqual(mock4);
+
+      expect(mockEntityRetrieved.count).toEqual(2);
+      expect(mockEntityRetrieved2.count).toEqual(2);
+
+      expect(mockEntityRetrieved.lastKey).toEqual({ partitionKey: 'PK1', sortKey: 'SK2' });
+      expect(mockEntityRetrieved2.lastKey).toEqual(undefined);
+    });
+
+    test('Should be able to retrieve multiple items with pagination (with GSI)', async () => {
+      // Arrange
+      const mock = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK1', GSI_1_PK: 'GPK1', GSI_1_SK: 1 });
+      const mock2 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK2', GSI_1_PK: 'GPK1', GSI_1_SK: 2 });
+      const mock3 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK3', GSI_1_PK: 'GPK1', GSI_1_SK: 3 });
+      const mock4 = mockEntityFactory({ partitionKey: 'PK1', sortKey: 'SK4', GSI_1_PK: 'GPK1', GSI_1_SK: 4 });
+      await MockEntityManager.put(mock);
+      await MockEntityManager.put(mock2);
+      await MockEntityManager.put(mock3);
+      await MockEntityManager.put(mock4);
+
+      // Act
+      const mockEntityRetrieved = await MockEntityManager.query().partitionKey('GSI_1_PK').eq('GPK1').limit(2).run();
+      const mockEntityRetrieved2 = await MockEntityManager.query()
+        .partitionKey('GSI_1_PK')
+        .eq('GPK1')
+        .startAt(mockEntityRetrieved.lastKey)
+        .run();
+
+      // Assert
+      expect(mockEntityRetrieved.items[0]).toEqual(mock);
+      expect(mockEntityRetrieved.items[1]).toEqual(mock2);
+      expect(mockEntityRetrieved2.items[0]).toEqual(mock3);
+      expect(mockEntityRetrieved2.items[1]).toEqual(mock4);
+
+      expect(mockEntityRetrieved.count).toEqual(2);
+      expect(mockEntityRetrieved2.count).toEqual(2);
+
+      expect(mockEntityRetrieved.lastKey).toEqual({
+        partitionKey: 'PK1',
+        sortKey: 'SK2',
+        GSI_1_PK: 'GPK1',
+        GSI_1_SK: 2,
+      });
+      expect(mockEntityRetrieved2.lastKey).toEqual(undefined);
+    });
+  });
+});

--- a/tests/unit/entity/helpers/converters.test.ts
+++ b/tests/unit/entity/helpers/converters.test.ts
@@ -4,7 +4,7 @@ import Dynamode from '@lib/dynamode/index';
 import { AttributesMetadata } from '@lib/dynamode/storage/types';
 import {
   convertAttributeValuesToEntity,
-  convertAttributeValuesToPrimaryKey,
+  convertAttributeValuesToLastKey,
   convertEntityToAttributeValues,
   convertPrimaryKeyToAttributeValues,
 } from '@lib/entity/helpers/converters';
@@ -169,7 +169,7 @@ describe('Converters entity helpers', () => {
     test('Should return composite primary key in dynamode format', async () => {
       getEntityMetadataSpy.mockReturnValue(metadata as any);
 
-      const dynamodePrimaryKey = convertAttributeValuesToPrimaryKey<TestTableMetadata, typeof MockEntity>(MockEntity, {
+      const dynamodePrimaryKey = convertAttributeValuesToLastKey<TestTableMetadata, typeof MockEntity>(MockEntity, {
         partitionKey: {
           S: 'pk_value',
         },
@@ -189,7 +189,7 @@ describe('Converters entity helpers', () => {
     test('Should return simple primary key in dynamode format', async () => {
       getEntityMetadataSpy.mockReturnValue({ partitionKey: 'partitionKey' } as any);
 
-      const dynamodePrimaryKey = convertAttributeValuesToPrimaryKey<TestTableMetadata, typeof MockEntity>(MockEntity, {
+      const dynamodePrimaryKey = convertAttributeValuesToLastKey<TestTableMetadata, typeof MockEntity>(MockEntity, {
         partitionKey: {
           S: 'pk_value',
         },

--- a/tests/unit/entity/helpers/converters.test.ts
+++ b/tests/unit/entity/helpers/converters.test.ts
@@ -243,7 +243,7 @@ describe('Converters entity helpers', () => {
   });
 
   describe('convertRetrieverLastKeyToAttributeValues', async () => {
-    test('Should return composite primary key in dynamo format', async () => {
+    test('Should return composite last key in dynamo format', async () => {
       getEntityMetadataSpy.mockReturnValue({ ...metadata, indexes: undefined } as any);
 
       const dynamoPrimaryKey = convertRetrieverLastKeyToAttributeValues<TestTableMetadata, typeof MockEntity>(
@@ -266,7 +266,7 @@ describe('Converters entity helpers', () => {
       expect(transformValueSpy).toHaveBeenNthCalledWith(2, MockEntity, metadata.sortKey, 'sk_value');
     });
 
-    test('Should return simple primary key in dynamo format', async () => {
+    test('Should return simple last key in dynamo format', async () => {
       getEntityMetadataSpy.mockReturnValue({ partitionKey: 'partitionKey' } as any);
 
       const dynamoPrimaryKey = convertRetrieverLastKeyToAttributeValues(MockEntity, {
@@ -282,7 +282,7 @@ describe('Converters entity helpers', () => {
       expect(transformValueSpy).toBeCalledTimes(1);
     });
 
-    test('Should return composite primary key in dynamo format', async () => {
+    test('Should return composite (+ indexes) last key in dynamo format', async () => {
       getEntityMetadataSpy.mockReturnValue(metadata as any);
 
       const dynamoPrimaryKey = convertRetrieverLastKeyToAttributeValues<TestTableMetadata, typeof MockEntity>(

--- a/tests/unit/entity/helpers/converters.test.ts
+++ b/tests/unit/entity/helpers/converters.test.ts
@@ -7,6 +7,7 @@ import {
   convertAttributeValuesToLastKey,
   convertEntityToAttributeValues,
   convertPrimaryKeyToAttributeValues,
+  convertRetrieverLastKeyToAttributeValues,
 } from '@lib/entity/helpers/converters';
 import * as transformValuesHelpers from '@lib/entity/helpers/transformValues';
 
@@ -238,6 +239,90 @@ describe('Converters entity helpers', () => {
       });
       expect(transformValueSpy).toBeCalledWith(MockEntity, metadata.partitionKey, 'pk_value');
       expect(transformValueSpy).toBeCalledTimes(1);
+    });
+  });
+
+  describe('convertRetrieverLastKeyToAttributeValues', async () => {
+    test('Should return composite primary key in dynamo format', async () => {
+      getEntityMetadataSpy.mockReturnValue({ ...metadata, indexes: undefined } as any);
+
+      const dynamoPrimaryKey = convertRetrieverLastKeyToAttributeValues<TestTableMetadata, typeof MockEntity>(
+        MockEntity,
+        {
+          partitionKey: 'pk_value',
+          sortKey: 'sk_value',
+        },
+      );
+
+      expect(dynamoPrimaryKey).toEqual({
+        partitionKey: {
+          S: 'pk_value',
+        },
+        sortKey: {
+          S: 'sk_value',
+        },
+      });
+      expect(transformValueSpy).toHaveBeenNthCalledWith(1, MockEntity, metadata.partitionKey, 'pk_value');
+      expect(transformValueSpy).toHaveBeenNthCalledWith(2, MockEntity, metadata.sortKey, 'sk_value');
+    });
+
+    test('Should return simple primary key in dynamo format', async () => {
+      getEntityMetadataSpy.mockReturnValue({ partitionKey: 'partitionKey' } as any);
+
+      const dynamoPrimaryKey = convertRetrieverLastKeyToAttributeValues(MockEntity, {
+        partitionKey: 'pk_value',
+      } as any);
+
+      expect(dynamoPrimaryKey).toEqual({
+        partitionKey: {
+          S: 'pk_value',
+        },
+      });
+      expect(transformValueSpy).toBeCalledWith(MockEntity, metadata.partitionKey, 'pk_value');
+      expect(transformValueSpy).toBeCalledTimes(1);
+    });
+
+    test('Should return composite primary key in dynamo format', async () => {
+      getEntityMetadataSpy.mockReturnValue(metadata as any);
+
+      const dynamoPrimaryKey = convertRetrieverLastKeyToAttributeValues<TestTableMetadata, typeof MockEntity>(
+        MockEntity,
+        {
+          partitionKey: 'pk_value',
+          sortKey: 'sk_value',
+          GSI_1_PK: 'gsi_1_pk_value',
+          GSI_1_SK: 111,
+          LSI_1_SK: 222,
+        },
+      );
+
+      expect(dynamoPrimaryKey).toEqual({
+        partitionKey: {
+          S: 'pk_value',
+        },
+        sortKey: {
+          S: 'sk_value',
+        },
+        GSI_1_PK: {
+          S: 'gsi_1_pk_value',
+        },
+        GSI_1_SK: {
+          N: '111',
+        },
+        LSI_1_SK: {
+          N: '222',
+        },
+      });
+      expect(transformValueSpy).toHaveBeenNthCalledWith(
+        1,
+        MockEntity,
+        metadata.indexes.GSI_1_NAME.partitionKey,
+        'gsi_1_pk_value',
+      );
+      expect(transformValueSpy).toHaveBeenNthCalledWith(2, MockEntity, metadata.indexes.GSI_1_NAME.sortKey, 111);
+      expect(transformValueSpy).toHaveBeenNthCalledWith(3, MockEntity, metadata.indexes.LSI_1_NAME.sortKey, 222);
+      expect(transformValueSpy).toHaveBeenNthCalledWith(4, MockEntity, metadata.partitionKey, 'pk_value');
+      expect(transformValueSpy).toHaveBeenNthCalledWith(5, MockEntity, metadata.sortKey, 'sk_value');
     });
   });
 });

--- a/tests/unit/entity/helpers/converters.test.ts
+++ b/tests/unit/entity/helpers/converters.test.ts
@@ -165,7 +165,7 @@ describe('Converters entity helpers', () => {
     });
   });
 
-  describe('convertAttributeValuesToPrimaryKey', async () => {
+  describe('convertAttributeValuesToLastKey', async () => {
     test('Should return composite primary key in dynamode format', async () => {
       getEntityMetadataSpy.mockReturnValue(metadata as any);
 

--- a/tests/unit/query/index.test.ts
+++ b/tests/unit/query/index.test.ts
@@ -56,7 +56,7 @@ describe('Query', () => {
 
     let buildQueryInputSpy = vi.spyOn(query, 'buildQueryInput' as any);
     let convertAttributeValuesToEntitySpy = vi.spyOn(entityConvertHelpers, 'convertAttributeValuesToEntity');
-    let convertAttributeValuesToPrimaryKeySpy = vi.spyOn(entityConvertHelpers, 'convertAttributeValuesToPrimaryKey');
+    let convertAttributeValuesToLastKeySpy = vi.spyOn(entityConvertHelpers, 'convertAttributeValuesToLastKey');
     let timeoutSpy = vi.spyOn(utils, 'timeout');
 
     const queryInput: QueryInput = {
@@ -73,8 +73,8 @@ describe('Query', () => {
       convertAttributeValuesToEntitySpy = vi
         .spyOn(entityConvertHelpers, 'convertAttributeValuesToEntity')
         .mockReturnValue(mockInstance);
-      convertAttributeValuesToPrimaryKeySpy = vi
-        .spyOn(entityConvertHelpers, 'convertAttributeValuesToPrimaryKey')
+      convertAttributeValuesToLastKeySpy = vi
+        .spyOn(entityConvertHelpers, 'convertAttributeValuesToLastKey')
         .mockReturnValue({ partitionKey: 'lastValue', sortKey: 'lastValue' } as any);
       timeoutSpy = vi.spyOn(utils, 'timeout').mockImplementation(async () => undefined);
     });
@@ -89,14 +89,14 @@ describe('Query', () => {
       expect(buildQueryInputSpy).toBeCalledWith({ IndexName: 'indexName' });
       expect(timeoutSpy).not.toBeCalled();
       expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-      expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+      expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
     });
 
     test('Should return query input for return = "input"', async () => {
       expect(query.run({ return: 'input' })).toEqual(queryInput);
       expect(timeoutSpy).not.toBeCalled();
       expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-      expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+      expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
     });
 
     test('Should return query output for return = "output"', async () => {
@@ -107,7 +107,7 @@ describe('Query', () => {
       await expect(query.run({ return: 'output' })).resolves.toEqual({ Items: 'test' });
       expect(timeoutSpy).not.toBeCalled();
       expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-      expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+      expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
     });
 
     describe('With option return = "default"', () => {
@@ -136,7 +136,7 @@ describe('Query', () => {
 
         expect(timeoutSpy).not.toBeCalled();
         expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-        expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+        expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
       });
 
       test('Should return items with values returned', async () => {
@@ -149,7 +149,7 @@ describe('Query', () => {
           };
         });
         convertAttributeValuesToEntitySpy.mockReturnValue(mockInstance);
-        convertAttributeValuesToPrimaryKeySpy.mockReturnValue({
+        convertAttributeValuesToLastKeySpy.mockReturnValue({
           partitionKey: 'lastValue',
           sortKey: 'lastValue',
         } as any);
@@ -164,8 +164,8 @@ describe('Query', () => {
         expect(timeoutSpy).not.toBeCalled();
         expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(1);
         expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, { key: 'value' });
-        expect(convertAttributeValuesToPrimaryKeySpy).toBeCalledTimes(1);
-        expect(convertAttributeValuesToPrimaryKeySpy).toBeCalledWith(MockEntity, {
+        expect(convertAttributeValuesToLastKeySpy).toBeCalledTimes(1);
+        expect(convertAttributeValuesToLastKeySpy).toBeCalledWith(MockEntity, {
           partitionKey: 'lastValue',
           sortKey: 'lastValue',
         });
@@ -196,7 +196,7 @@ describe('Query', () => {
         expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, { key: 'value1' });
         expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, { key: 'value2' });
         expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(3, MockEntity, { key: 'value3' });
-        expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+        expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
       });
 
       test('Should return items with "all: true, max: 2, delay: 10" options', async () => {
@@ -209,7 +209,7 @@ describe('Query', () => {
           });
 
         convertAttributeValuesToEntitySpy.mockReturnValue(mockInstance);
-        convertAttributeValuesToPrimaryKeySpy.mockImplementation((entity, lastKey) => lastKey as any);
+        convertAttributeValuesToLastKeySpy.mockImplementation((entity, lastKey) => lastKey as any);
 
         await expect(query.run({ all: true, max: 2 })).resolves.toEqual({
           items: [mockInstance, mockInstance],
@@ -222,8 +222,8 @@ describe('Query', () => {
         expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(2);
         expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, { key: 'value1' });
         expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, { key: 'value2' });
-        expect(convertAttributeValuesToPrimaryKeySpy).toBeCalledTimes(1);
-        expect(convertAttributeValuesToPrimaryKeySpy).toBeCalledWith(MockEntity, { key: 'value2' });
+        expect(convertAttributeValuesToLastKeySpy).toBeCalledTimes(1);
+        expect(convertAttributeValuesToLastKeySpy).toBeCalledWith(MockEntity, { key: 'value2' });
       });
     });
   });

--- a/tests/unit/retriever/index.test.ts
+++ b/tests/unit/retriever/index.test.ts
@@ -32,12 +32,15 @@ describe('RetrieverBase', () => {
   });
 
   describe('startAt', () => {
-    const convertPrimaryKeyToAttributeValuesSpy = vi.spyOn(entityConvertHelpers, 'convertPrimaryKeyToAttributeValues');
-    convertPrimaryKeyToAttributeValuesSpy.mockImplementation(() => ({
+    const convertRetrieverLastKeyToAttributeValuesSpy = vi.spyOn(
+      entityConvertHelpers,
+      'convertRetrieverLastKeyToAttributeValues',
+    );
+    convertRetrieverLastKeyToAttributeValuesSpy.mockImplementation(() => ({
       partitionKey: { S: 'partitionKey' },
       sortKey: { S: 'sortKey' },
     }));
-    beforeEach(async () => convertPrimaryKeyToAttributeValuesSpy.mockReset);
+    beforeEach(async () => convertRetrieverLastKeyToAttributeValuesSpy.mockReset);
 
     test('Should set ExclusiveStartKey on query/scan input', async () => {
       retriever.startAt({ partitionKey: 'partitionKey', sortKey: 'sortKey' });
@@ -46,7 +49,7 @@ describe('RetrieverBase', () => {
         partitionKey: { S: 'partitionKey' },
         sortKey: { S: 'sortKey' },
       });
-      expect(convertPrimaryKeyToAttributeValuesSpy).toBeCalledWith(MockEntity, {
+      expect(convertRetrieverLastKeyToAttributeValuesSpy).toBeCalledWith(MockEntity, {
         partitionKey: 'partitionKey',
         sortKey: 'sortKey',
       });
@@ -56,7 +59,7 @@ describe('RetrieverBase', () => {
       retriever.startAt(undefined);
 
       expect(retriever['input']['ExclusiveStartKey']).toEqual(undefined);
-      expect(convertPrimaryKeyToAttributeValuesSpy).not.toBeCalled();
+      expect(convertRetrieverLastKeyToAttributeValuesSpy).not.toBeCalled();
     });
   });
 

--- a/tests/unit/scan/index.test.ts
+++ b/tests/unit/scan/index.test.ts
@@ -46,7 +46,7 @@ describe('Scan', () => {
 
     let buildScanInputSpy = vi.spyOn(scan, 'buildScanInput' as any);
     let convertAttributeValuesToEntitySpy = vi.spyOn(entityConvertHelpers, 'convertAttributeValuesToEntity');
-    let convertAttributeValuesToPrimaryKeySpy = vi.spyOn(entityConvertHelpers, 'convertAttributeValuesToPrimaryKey');
+    let convertAttributeValuesToLastKeySpy = vi.spyOn(entityConvertHelpers, 'convertAttributeValuesToLastKey');
 
     const scanInput: ScanInput = {
       TableName: TEST_TABLE_NAME,
@@ -60,8 +60,8 @@ describe('Scan', () => {
       convertAttributeValuesToEntitySpy = vi
         .spyOn(entityConvertHelpers, 'convertAttributeValuesToEntity')
         .mockReturnValue(mockInstance);
-      convertAttributeValuesToPrimaryKeySpy = vi
-        .spyOn(entityConvertHelpers, 'convertAttributeValuesToPrimaryKey')
+      convertAttributeValuesToLastKeySpy = vi
+        .spyOn(entityConvertHelpers, 'convertAttributeValuesToLastKey')
         .mockReturnValue({ partitionKey: 'lastValue', sortKey: 'lastValue' } as any);
     });
 
@@ -74,13 +74,13 @@ describe('Scan', () => {
       scan.run({ return: 'input', extraInput: { IndexName: 'indexName' } });
       expect(buildScanInputSpy).toBeCalledWith({ IndexName: 'indexName' });
       expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-      expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+      expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
     });
 
     test('Should return scan input for return = "input"', async () => {
       expect(scan.run({ return: 'input' })).toEqual(scanInput);
       expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-      expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+      expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
     });
 
     test('Should return scan output for return = "output"', async () => {
@@ -90,7 +90,7 @@ describe('Scan', () => {
 
       await expect(scan.run({ return: 'output' })).resolves.toEqual({ Items: 'test' });
       expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-      expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+      expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
     });
 
     test('Should return no items with no values returned for return = "output"', async () => {
@@ -116,7 +116,7 @@ describe('Scan', () => {
       });
 
       expect(convertAttributeValuesToEntitySpy).not.toBeCalled();
-      expect(convertAttributeValuesToPrimaryKeySpy).not.toBeCalled();
+      expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
     });
 
     test('Should return items with values returned for return = "output"', async () => {
@@ -129,7 +129,7 @@ describe('Scan', () => {
         };
       });
       convertAttributeValuesToEntitySpy.mockReturnValue(mockInstance);
-      convertAttributeValuesToPrimaryKeySpy.mockReturnValue({ partitionKey: 'lastValue', sortKey: 'lastValue' } as any);
+      convertAttributeValuesToLastKeySpy.mockReturnValue({ partitionKey: 'lastValue', sortKey: 'lastValue' } as any);
 
       await expect(scan.run({ return: 'default' })).resolves.toEqual({
         items: [mockInstance],
@@ -140,8 +140,8 @@ describe('Scan', () => {
 
       expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(1);
       expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, { key: 'value' });
-      expect(convertAttributeValuesToPrimaryKeySpy).toBeCalledTimes(1);
-      expect(convertAttributeValuesToPrimaryKeySpy).toBeCalledWith(MockEntity, {
+      expect(convertAttributeValuesToLastKeySpy).toBeCalledTimes(1);
+      expect(convertAttributeValuesToLastKeySpy).toBeCalledWith(MockEntity, {
         partitionKey: 'lastValue',
         sortKey: 'lastValue',
       });


### PR DESCRIPTION
### Summary:

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:

#### Model
```ts
// Code here
```

#### General
```ts
// Code here
```

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:

#----


### Type of change:
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Something not listed here


### Is this a breaking change?
- [ ] YES 🚨
- [ ] No

### Other:
- [ ] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamode documentation (if required)
- [ ] I have added/updated the Dynamode test cases (if required) 
- [ ] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamode License](../LICENSE).
