### PR TITLE
Add a decorator to set custom names for entities

### DIFF
--- a/docs/docs/guide/entity/decorators.mdx
+++ b/docs/docs/guide/entity/decorators.mdx
@@ -27,6 +27,28 @@ Add following lines in `tsconfig.json` in order to use decorators with Typescrip
 
 To see examples of decorators in use - check out [modeling](/docs/guide/entity/modeling) page.
 
+## entity.customName(entityName)
+### Description
+
+This decorator is used to change the name of the entity. By default, the name of the entity is the name of the class. This is especially useful when you use minification or obfuscation tools.
+
+### Arguments
+
+`entityName: string` - String that will be used as the new name for the entity.
+
+### Examples
+
+```ts
+import {entity} from 'dynamode/decorators';
+
+@entity.customName("CustomName")
+class YourModel extends Entity { 
+  ...
+}
+
+console.log(YourModel.constructor.name); // CustomName
+```
+
 ## attribute.partitionKey.string(options?)
 ### Description
 

--- a/docs/docs/guide/entity/modeling.mdx
+++ b/docs/docs/guide/entity/modeling.mdx
@@ -50,7 +50,7 @@ class YourModel extends Entity {
 
 ### Decorators
 
-**Only decorated properties will be saved in the database.** Thanks to this you can add undecorated properties to your entity that won't be saved but can be useful for your application logic.
+**Only decorated properties will be saved in the database.** Thanks to this you can add undecorated properties to your entity that won't be saved but can be useful for your application logic. Check out the list of decorators [here](/docs/guide/entity/decorators).
 
 :::caution
 There are no limits to the number of attributes that you can add, but keep in mind the [DynamoDB size limits](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html).
@@ -89,12 +89,44 @@ class YourModel extends Entity {
 }
 ```
 
+### dynamodeEntity property
+
+Every entity has a `dynamodeEntity` property that is used to identify the entity in the database. It is a string that represents the class name of the entity. 
+
+:::danger
+Each of your entities names must be unique within a table. Dynamode uses class names to identify entities.
+:::
+
+```ts
+import Entity from 'dynamode/entity';
+
+class YourModel extends Entity {
+  ...
+}
+
+const instance = YourModelManager.get({ key: '...' });
+console.log(instance.dynamodeEntity); // YourModel
+```
+
+```ts
+import Entity from 'dynamode/entity';
+import {entity} from 'dynamode/decorators';
+
+@entity.customName('CustomName')
+class YourModel extends Entity {
+  ...
+}
+
+const instance = YourModelManager.get({ key: '...' });
+console.log(instance.dynamodeEntity); // CustomName
+```
+
 ### Additional methods
 
 You can add non-static and static methods to your entities that you can call later. You can also add static properties that will be available in your class.
 
 :::danger
-Do not override `Entity.dynamodeEntity` static property, unless you know what you are doing.
+Do not override `Entity.dynamodeEntity` property, unless you know what you are doing. 
 :::
 
 ```ts

--- a/lib/decorators/helpers/customName.ts
+++ b/lib/decorators/helpers/customName.ts
@@ -1,13 +1,13 @@
 import Dynamode from '@lib/dynamode/index';
 
-function customName(newName: string): ClassDecorator {
+function customName(newNameEntity: string): ClassDecorator {
   return (entity: any) => {
-    const oldName = entity.name;
+    const oldNameEntity = entity.name;
     Object.defineProperty(entity, 'name', {
       writable: true,
-      value: newName,
+      value: newNameEntity,
     });
-    Dynamode.storage.renameEntity(oldName, newName);
+    Dynamode.storage.transferMetadata(oldNameEntity, newNameEntity);
   };
 }
 

--- a/lib/decorators/helpers/customName.ts
+++ b/lib/decorators/helpers/customName.ts
@@ -1,0 +1,14 @@
+import Dynamode from '@lib/dynamode/index';
+
+function customName(newName: string): ClassDecorator {
+  return (entity: any) => {
+    const oldName = entity.name;
+    Object.defineProperty(entity, 'name', {
+      writable: true,
+      value: newName,
+    });
+    Dynamode.storage.renameEntity(oldName, newName);
+  };
+}
+
+export default customName;

--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -1,3 +1,4 @@
+import customName from '@lib/decorators/helpers/customName';
 import { numberDate, stringDate } from '@lib/decorators/helpers/dates';
 import {
   numberGsiPartitionKey,
@@ -58,4 +59,9 @@ const attribute = {
   suffix,
 };
 
+const entity = {
+  customName,
+};
+
 export default attribute;
+export { entity };

--- a/lib/dynamode/storage/index.ts
+++ b/lib/dynamode/storage/index.ts
@@ -156,10 +156,7 @@ export default class DynamodeStorage {
   }
 
   public renameEntity(oldName: string, newName: string): void {
-    if (this.entities[newName] && this.entities[oldName]?.attributes) {
-      this.entities[newName].attributes = this.entities[oldName].attributes;
-    }
-
+    this.entities[newName] = this.entities[oldName];
     delete this.entities[oldName];
   }
 

--- a/lib/dynamode/storage/index.ts
+++ b/lib/dynamode/storage/index.ts
@@ -155,6 +155,11 @@ export default class DynamodeStorage {
     return this.tables[tableName].metadata;
   }
 
+  public renameEntity(oldName: string, newName: string): void {
+    this.entities[newName] = { ...this.entities[newName], ...this.entities[oldName] };
+    delete this.entities[oldName];
+  }
+
   public validateTableMetadata(entityName: string): void {
     const metadata = this.getEntityMetadata(entityName);
     const attributes = this.getEntityAttributes(entityName);

--- a/lib/dynamode/storage/index.ts
+++ b/lib/dynamode/storage/index.ts
@@ -156,7 +156,10 @@ export default class DynamodeStorage {
   }
 
   public renameEntity(oldName: string, newName: string): void {
-    this.entities[newName].attributes = this.entities[oldName].attributes;
+    if (this.entities[newName] && this.entities[oldName]?.attributes) {
+      this.entities[newName].attributes = this.entities[oldName].attributes;
+    }
+
     delete this.entities[oldName];
   }
 

--- a/lib/dynamode/storage/index.ts
+++ b/lib/dynamode/storage/index.ts
@@ -155,9 +155,13 @@ export default class DynamodeStorage {
     return this.tables[tableName].metadata;
   }
 
-  public renameEntity(oldName: string, newName: string): void {
-    this.entities[newName] = this.entities[oldName];
-    delete this.entities[oldName];
+  public transferMetadata(oldNameEntity: string, newNameEntity: string): void {
+    if (newNameEntity === oldNameEntity) {
+      return;
+    }
+
+    this.entities[newNameEntity] = this.entities[oldNameEntity];
+    delete this.entities[oldNameEntity];
   }
 
   public validateTableMetadata(entityName: string): void {

--- a/lib/dynamode/storage/index.ts
+++ b/lib/dynamode/storage/index.ts
@@ -156,7 +156,7 @@ export default class DynamodeStorage {
   }
 
   public renameEntity(oldName: string, newName: string): void {
-    this.entities[newName] = { ...this.entities[newName], ...this.entities[oldName] };
+    this.entities[newName].attributes = this.entities[oldName].attributes;
     delete this.entities[oldName];
   }
 

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 import Condition, { AttributeType } from '@lib/condition';
-import attribute from '@lib/decorators';
+import attribute, { entity } from '@lib/decorators';
 import Dynamode from '@lib/dynamode/index';
 import Entity from '@lib/entity';
 import Query from '@lib/query';
@@ -26,6 +26,7 @@ export {
 
   //decorators
   attribute,
+  entity,
 
   //Entity
   Entity,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.1",
+  "version": "1.4.1-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.4.1-rc.1",
+      "version": "1.4.1-rc.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.474.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.3",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.4.1-rc.3",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.474.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.4.0",
+  "version": "1.4.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.4.0",
+      "version": "1.4.1-rc.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.474.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.2",
+  "version": "1.4.1-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.4.1-rc.2",
+      "version": "1.4.1-rc.3",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.474.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.0",
+  "version": "1.4.1-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.4.1-rc.0",
+      "version": "1.4.1-rc.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.474.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.3",
+  "version": "1.5.0",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.1",
+  "version": "1.4.1-rc.2",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "test:types": "vitest run types --typecheck",
     "coverage": "vitest run unit --coverage",
     "lint": "eslint lib --ext .ts,.js --max-warnings 0",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "bump:patch": "npm version patch",
+    "bump:minor": "npm version minor",
+    "bump:major": "npm version major",
+    "bump:next": "npm version prerelease --preid rc",
+    "publish:next": "npm run build && cd dist && npm publish --tag next"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.474.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.2",
+  "version": "1.4.1-rc.3",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.4.1-rc.0",
+  "version": "1.4.1-rc.1",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.4.0",
+  "version": "1.4.1-rc.0",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/fixtures/TestIndex.ts
+++ b/tests/fixtures/TestIndex.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-import attribute from '@lib/decorators';
+import attribute, { entity } from '@lib/decorators';
 import Dynamode from '@lib/dynamode/index';
 import Entity from '@lib/entity';
 import TableManager from '@lib/table';
@@ -28,6 +28,7 @@ export class TestIndex extends Entity {
   }
 }
 
+@entity.customName('TEST_INDEX_GSI')
 export class TestIndexWithGSI extends TestIndex {
   // TODO: Make it so that partitionKey decorator is not required for a second time
   @attribute.partitionKey.number()

--- a/tests/unit/decorators/helpers/customName.test.ts
+++ b/tests/unit/decorators/helpers/customName.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import customName from '@lib/decorators/helpers/customName';
+import Dynamode from '@lib/dynamode/index';
+
+describe('Decorators', () => {
+  let transferMetadataSpy = vi.spyOn(Dynamode.storage, 'transferMetadata');
+
+  beforeEach(() => {
+    transferMetadataSpy = vi.spyOn(Dynamode.storage, 'transferMetadata');
+    transferMetadataSpy.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('customName', async () => {
+    test('Should call transfer metadata when renaming an entity', async () => {
+      customName('NEW_NAME')(class OLD_NAME {});
+      expect(transferMetadataSpy).toHaveBeenNthCalledWith(1, 'OLD_NAME', 'NEW_NAME');
+    });
+
+    test('Should call transfer metadata when renaming an entity with the same name', async () => {
+      customName('OLD_NAME')(class OLD_NAME {});
+      expect(transferMetadataSpy).toHaveBeenNthCalledWith(1, 'OLD_NAME', 'OLD_NAME');
+    });
+  });
+});

--- a/tests/unit/dynamode/index.test.ts
+++ b/tests/unit/dynamode/index.test.ts
@@ -379,6 +379,47 @@ describe('Dynamode', () => {
       });
     });
 
+    describe('transferMetadata', async () => {
+      test('Should transfer metadata to a different name', async () => {
+        storage.registerAttribute('OLD_NAME', 'prop', {
+          propertyName: 'prop',
+          type: Number,
+          role: 'attribute',
+        });
+        storage.transferMetadata('OLD_NAME', 'NEW_NAME');
+
+        expect(storage.entities['NEW_NAME']).toEqual({
+          attributes: {
+            prop: {
+              propertyName: 'prop',
+              type: Number,
+              role: 'attribute',
+            },
+          },
+        });
+        expect(storage.entities['OLD_NAME']).toEqual(undefined);
+      });
+
+      test('Should preserve metadata when the same name was used', async () => {
+        storage.registerAttribute('OLD_NAME', 'prop', {
+          propertyName: 'prop',
+          type: Number,
+          role: 'attribute',
+        });
+        storage.transferMetadata('OLD_NAME', 'OLD_NAME');
+
+        expect(storage.entities['OLD_NAME']).toEqual({
+          attributes: {
+            prop: {
+              propertyName: 'prop',
+              type: Number,
+              role: 'attribute',
+            },
+          },
+        });
+      });
+    });
+
     describe('validateTableMetadata', async () => {
       let validateMetadataAttribute = vi.spyOn(storageHelper, 'validateMetadataAttribute');
       let getEntityMetadata = vi.spyOn(storage, 'getEntityMetadata');


### PR DESCRIPTION
Fixes https://github.com/blazejkustra/dynamode/issues/32. Now it is possible to overwrite the name of the class with a decorator.

```ts
import Table, { tableManager, TableProps } from "./table";
import attribute, { entity } from "dynamode/decorators";

export interface UserProps {
  pk: string;
}

@entity.customName("USER_ENTITY")
export class User extends Table {
  @attribute.partitionKey.string({ prefix: "USER" })
  pk!: string;

  constructor(props: UserProps) {
    super(props);
  }
}

export const UserManager = tableManager.entityManager(User);
```

The outcome is that you get entity names even with minification: ![image](https://private-user-images.githubusercontent.com/46095609/354811864-80aed15b-584a-4205-a337-a8c2e7cd4e42.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjI3ODcwMTAsIm5iZiI6MTcyMjc4NjcxMCwicGF0aCI6Ii80NjA5NTYwOS8zNTQ4MTE4NjQtODBhZWQxNWItNTg0YS00MjA1LWEzMzctYThjMmU3Y2Q0ZTQyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MDQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODA0VDE1NTE1MFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWY3YTFkMTZhYmQ1ZjQ2ZTM4MzkzODVhZWRjNjQ4MGNiNmQ0NTRhOThlNzYzNmM0YzMyNjQ0NjFmMzIxNmM5ZGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.8Not9QWfkcxfmaBIauQMP2wsOvVbgvnG_HngIQVltKY)

