### PR TITLE
Fix: Entity constructor overrides attributes on projection/selective Get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- JSDoc documentation was added to the project ([#40](https://github.com/blazejkustra/dynamode/pull/40))
+- Enhanced entity conversion to handle attribute selection in EntityManager `get()` and `batchGet()` methods
+
+### Changed
+- Bump AWS SDK packages to version 3.883.0 & improve type safety ([#42](https://github.com/blazejkustra/dynamode/pull/40))
+
+### Fixed
+- Fix import example in documentation ([#37](https://github.com/blazejkustra/dynamode/pull/37)) - Thanks @gmreburn!
+
+## [1.5.0] - 2024-08-15
+
+### Added
+- `@attribute.customName()` decorator to set custom names for entity attributes ([#33](https://github.com/blazejkustra/dynamode/pull/33))
+- Tests for `customName` decorator
+
+### Fixed
+- Fixed entity renaming logic
+- Improved code safety and error handling
+
+## [1.4.0] - 2024-07-21
+
+### Added
+- Support for multiple GSI decorators on the same attribute ([#28](https://github.com/blazejkustra/dynamode/pull/28), [#29](https://github.com/blazejkustra/dynamode/pull/29))
+- Allow GSI decorators to decorate both partition and sort keys interchangeably ([#31](https://github.com/blazejkustra/dynamode/pull/31))
+
+### Changed
+- Moved test fixtures to a dedicated catalog
+- Improved test organization and coverage
+
+### Fixed
+- Fixed issue where multiple attribute decorators could not be added to primary keys
+- Fixed typecheck issues
+
+## [1.3.0] - 2024-06-23
+
+### Added
+- Support for decorating an attribute with multiple indexes ([#28](https://github.com/blazejkustra/dynamode/pull/28))
+
+## [1.2.0] - 2024-04-17
+
+### Added
+- Binary data type support ([#26](https://github.com/blazejkustra/dynamode/pull/26))
+
+## [1.1.0] - 2024-04-13
+
+### Fixed
+- Fixed `startAt` fails when querying secondary indices
+
+## [1.0.0] - 2024-03-24
+
+### Added
+- 🎉 Dynamode is now out of beta!
+- DynamoDB stream support ([#21](https://github.com/blazejkustra/dynamode/pull/21))
+
+## Earlier Versions
+
+For changes in earlier versions (< 1.0.0), please refer to the [Git commit history](https://github.com/blazejkustra/dynamode/commits/main).
+

--- a/lib/entity/entityManager.ts
+++ b/lib/entity/entityManager.ts
@@ -237,7 +237,7 @@ export default function EntityManager<M extends Metadata<E>, E extends typeof En
         throw new NotFoundError();
       }
 
-      return convertAttributeValuesToEntity(entity, result.Item);
+      return convertAttributeValuesToEntity(entity, result.Item, options?.attributes);
     })();
   }
 
@@ -701,7 +701,7 @@ export default function EntityManager<M extends Metadata<E>, E extends typeof En
         result.UnprocessedKeys?.[tableName]?.Keys?.map((key) => fromDynamo(key) as TablePrimaryKey<M, E>) || [];
 
       return {
-        items: items.map((item) => convertAttributeValuesToEntity(entity, item)),
+        items: items.map((item) => convertAttributeValuesToEntity(entity, item, options?.attributes)),
         unprocessedKeys,
       };
     })();

--- a/lib/entity/helpers/converters.ts
+++ b/lib/entity/helpers/converters.ts
@@ -50,8 +50,6 @@ export function convertEntityToAttributeValues<E extends typeof Entity>(
   const dynamoObject: GenericObject = {};
   const attributes = Dynamode.storage.getEntityAttributes(entity.name);
 
-  console.log(`%%% attributes`, attributes);
-
   Object.values(attributes).forEach((attribute) => {
     dynamoObject[attribute.propertyName] = transformValue(
       entity,

--- a/lib/entity/helpers/converters.ts
+++ b/lib/entity/helpers/converters.ts
@@ -29,11 +29,14 @@ export function convertAttributeValuesToEntity<E extends typeof Entity>(
   const instance = new entity(object) as InstanceType<E>;
 
   if (selectedAttributes && selectedAttributes.length > 0) {
+    // Remove nested attributes from the selected attributes
+    const selectedAttributesSet = new Set([
+      'dynamodeEntity',
+      ...selectedAttributes.map((attribute) => attribute.split('.')[0]),
+    ]);
+
     Object.values(attributes)
-      .filter(
-        (attribute) =>
-          !selectedAttributes.includes(attribute.propertyName) && attribute.propertyName !== 'dynamodeEntity',
-      )
+      .filter((attribute) => !selectedAttributesSet.has(attribute.propertyName))
       .forEach((attribute) => {
         // @ts-expect-error undefined is not assignable to every Entity's property
         instance[attribute.propertyName] = undefined;

--- a/lib/query/index.ts
+++ b/lib/query/index.ts
@@ -160,7 +160,7 @@ export default class Query<M extends Metadata<E>, E extends typeof Entity> exten
       } while (all && !!lastKey && count < max);
 
       return {
-        items: items.map((item) => convertAttributeValuesToEntity(this.entity, item)),
+        items: items.map((item) => convertAttributeValuesToEntity(this.entity, item, this.selectedAttributes)),
         lastKey: lastKey && convertAttributeValuesToLastKey(this.entity, lastKey),
         count,
         scannedCount,

--- a/lib/retriever/index.ts
+++ b/lib/retriever/index.ts
@@ -18,6 +18,8 @@ import { AttributeNames, AttributeValues } from '@lib/utils';
 export default class RetrieverBase<M extends Metadata<E>, E extends typeof Entity> extends Condition<E> {
   /** The DynamoDB input object (QueryInput or ScanInput) */
   protected input: QueryInput | ScanInput;
+  /** The list of attributes actually fetched from DynamoDB */
+  protected selectedAttributes: Array<EntityKey<E>> = [];
   /** Attribute names mapping for expression attribute names */
   protected attributeNames: AttributeNames = {};
   /** Attribute values mapping for expression attribute values */
@@ -165,6 +167,7 @@ export default class RetrieverBase<M extends Metadata<E>, E extends typeof Entit
       attributes,
       this.attributeNames,
     ).projectionExpression;
+    this.selectedAttributes = attributes;
     return this;
   }
 }

--- a/lib/scan/index.ts
+++ b/lib/scan/index.ts
@@ -113,7 +113,7 @@ export default class Scan<M extends Metadata<E>, E extends typeof Entity> extend
       const items = result.Items || [];
 
       return {
-        items: items.map((item) => convertAttributeValuesToEntity(this.entity, item)),
+        items: items.map((item) => convertAttributeValuesToEntity(this.entity, item, this.selectedAttributes)),
         count: result.Count || 0,
         scannedCount: result.ScannedCount || 0,
         lastKey: result.LastEvaluatedKey

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.5.1-rc.0",
+  "version": "1.6.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.5.1-rc.0",
+      "version": "1.6.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.883.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamode",
-  "version": "1.6.0-rc.0",
+  "version": "1.6.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamode",
-      "version": "1.6.0-rc.0",
+      "version": "1.6.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.883.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.6.0-rc.0",
+  "version": "1.6.0-rc.1",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamode",
-  "version": "1.5.1-rc.0",
+  "version": "1.6.0-rc.0",
   "description": "Dynamode is a modeling tool for Amazon's DynamoDB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/e2e/entity/batchGet.test.ts
+++ b/tests/e2e/entity/batchGet.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 
-import { MockEntityManager, TEST_TABLE_NAME, TestTableManager } from '../../fixtures/TestTable';
+import { MockEntity, MockEntityManager, TEST_TABLE_NAME, TestTableManager } from '../../fixtures/TestTable';
 import { mockEntityFactory } from '../mockEntityFactory';
 
 describe('EntityManager.batchGet', () => {
@@ -84,15 +84,15 @@ describe('EntityManager.batchGet', () => {
       expect(mocks).not.toEqual([mock1, mock2, mock3]);
       expect(mocks[0].number).toEqual(1);
       expect(mocks[0].string).toEqual('string');
-      expect(mocks[0].object).toEqual(undefined);
+      expect((mocks[0] as MockEntity).object).toEqual(undefined);
 
       expect(mocks[1].number).toEqual(1);
       expect(mocks[1].string).toEqual('string');
-      expect(mocks[1].object).toEqual(undefined);
+      expect((mocks[1] as MockEntity).object).toEqual(undefined);
 
       expect(mocks[2].number).toEqual(1);
       expect(mocks[2].string).toEqual('string');
-      expect(mocks[2].object).toEqual(undefined);
+      expect((mocks[2] as MockEntity).object).toEqual(undefined);
     });
   });
 });

--- a/tests/e2e/entity/get.test.ts
+++ b/tests/e2e/entity/get.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 
 import { NotFoundError } from '@lib/utils';
 
-import { MockEntityManager, TEST_TABLE_NAME, TestTableManager } from '../../fixtures/TestTable';
+import { MockEntity, MockEntityManager, TEST_TABLE_NAME, TestTableManager } from '../../fixtures/TestTable';
 import { mockEntityFactory } from '../mockEntityFactory';
 
 describe('EntityManager.get', () => {
@@ -57,10 +57,10 @@ describe('EntityManager.get', () => {
       // Assert
       expect(mockEntityRetrieved.string).toEqual('string');
       expect(mockEntityRetrieved.number).toEqual(1);
-      expect(mockEntityRetrieved.boolean).toEqual(undefined);
-      expect(mockEntityRetrieved.object).toEqual(undefined);
-      expect(mockEntityRetrieved.partitionKey).toEqual(undefined);
-      expect(mockEntityRetrieved.sortKey).toEqual(undefined);
+      expect((mockEntityRetrieved as MockEntity).boolean).toEqual(undefined);
+      expect((mockEntityRetrieved as MockEntity).object).toEqual(undefined);
+      expect((mockEntityRetrieved as MockEntity).partitionKey).toEqual(undefined);
+      expect((mockEntityRetrieved as MockEntity).sortKey).toEqual(undefined);
     });
   });
 });

--- a/tests/fixtures/TestTable.ts
+++ b/tests/fixtures/TestTable.ts
@@ -209,4 +209,17 @@ export const mockInstance = new MockEntity({
   binary: new Uint8Array([1, 2, 3]),
 });
 
+export const partialMockInstance = new MockEntity({
+  string: 'string',
+  map: new Map([['1', '2']]),
+} as MockEntityProps);
+// @ts-expect-error Values are set to undefined on purpose
+partialMockInstance.strDate = undefined;
+// @ts-expect-error Values are set to undefined on purpose
+partialMockInstance.numDate = undefined;
+// @ts-expect-error Values are set to undefined on purpose
+partialMockInstance.createdAt = undefined;
+// @ts-expect-error Values are set to undefined on purpose
+partialMockInstance.updatedAt = undefined;
+
 vi.useRealTimers();

--- a/tests/types/EntityKey.test.ts
+++ b/tests/types/EntityKey.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable unused-imports/no-unused-vars */
 import { describe, expectTypeOf, test } from 'vitest';
 
 import Entity from '@lib/entity';

--- a/tests/types/EntitySelectedAttributes.test.ts
+++ b/tests/types/EntitySelectedAttributes.test.ts
@@ -1,0 +1,177 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable unused-imports/no-unused-vars */
+import { describe, expectTypeOf, test } from 'vitest';
+
+import Entity from '@lib/entity';
+import { EntitySelectedAttributes } from '@lib/entity/types';
+
+import { MockEntity } from '../fixtures/TestTable';
+
+class User extends Entity {
+  id!: string;
+  name!: string;
+  email!: string;
+  age!: number;
+  address!: string;
+}
+
+class NestedEntity extends Entity {
+  id!: string;
+  profile!: {
+    name: string;
+    bio?: string;
+  };
+  tags!: Array<string>;
+  metadata!: Record<string, string>;
+}
+
+describe('EntitySelectedAttributes type tests', () => {
+  test('Should return full InstanceType<E> when Attributes is undefined', () => {
+    type Result = EntitySelectedAttributes<typeof User, undefined>;
+    expectTypeOf<Result>().toEqualTypeOf<InstanceType<typeof User>>();
+  });
+
+  test('Should return full InstanceType<E> when Attributes is not provided', () => {
+    type Result = EntitySelectedAttributes<typeof User>;
+    expectTypeOf<Result>().toEqualTypeOf<InstanceType<typeof User>>();
+  });
+
+  test('Should return full InstanceType<E> when Attributes is empty array type', () => {
+    type Result = EntitySelectedAttributes<typeof User, []>;
+    expectTypeOf<Result>().toEqualTypeOf<InstanceType<typeof User>>();
+  });
+
+  test('Should narrow to single attribute plus dynamodeEntity', () => {
+    type Result = EntitySelectedAttributes<typeof User, ['id']>;
+
+    // Should have these properties
+    expectTypeOf<Result>().toHaveProperty('id');
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+
+    // Should NOT have these properties
+    expectTypeOf<Result>().not.toHaveProperty('name');
+    expectTypeOf<Result>().not.toHaveProperty('email');
+    expectTypeOf<Result>().not.toHaveProperty('age');
+    expectTypeOf<Result>().not.toHaveProperty('address');
+  });
+
+  test('Should narrow to multiple selected attributes plus dynamodeEntity', () => {
+    type Result = EntitySelectedAttributes<typeof User, ['id', 'name', 'email']>;
+
+    // Should have these properties
+    expectTypeOf<Result>().toHaveProperty('id');
+    expectTypeOf<Result>().toHaveProperty('name');
+    expectTypeOf<Result>().toHaveProperty('email');
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+
+    // Should NOT have these properties
+    expectTypeOf<Result>().not.toHaveProperty('age');
+    expectTypeOf<Result>().not.toHaveProperty('address');
+  });
+
+  test('Should preserve correct property types in narrowed result', () => {
+    type Result = EntitySelectedAttributes<typeof User, ['id', 'age']>;
+
+    expectTypeOf<Result>().toMatchTypeOf<{ id: string; age: number; dynamodeEntity: string }>();
+  });
+
+  test('Should work with nested object properties', () => {
+    type Result = EntitySelectedAttributes<typeof NestedEntity, ['id', 'profile', 'profile.name']>;
+
+    expectTypeOf<Result>().toHaveProperty('id');
+    expectTypeOf<Result>().toHaveProperty('profile');
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+
+    // Should NOT have these
+    expectTypeOf<Result>().not.toHaveProperty('tags');
+    expectTypeOf<Result>().not.toHaveProperty('metadata');
+  });
+
+  test('Should work with array properties', () => {
+    type Result = EntitySelectedAttributes<typeof NestedEntity, ['id', 'tags']>;
+
+    expectTypeOf<Result>().toHaveProperty('id');
+    expectTypeOf<Result>().toHaveProperty('tags');
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+
+    expectTypeOf<Result>().not.toHaveProperty('profile');
+    expectTypeOf<Result>().not.toHaveProperty('metadata');
+  });
+
+  test('Should always include dynamodeEntity even if not specified', () => {
+    type Result = EntitySelectedAttributes<typeof User, ['id']>;
+
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+    expectTypeOf<Result['dynamodeEntity']>().toEqualTypeOf<string>();
+  });
+
+  test('Should work with MockEntity complex structure', () => {
+    type Result = EntitySelectedAttributes<
+      typeof MockEntity,
+      ['partitionKey', 'sortKey', 'string', 'number', 'boolean']
+    >;
+
+    // Should have selected properties
+    expectTypeOf<Result>().toHaveProperty('partitionKey');
+    expectTypeOf<Result>().toHaveProperty('sortKey');
+    expectTypeOf<Result>().toHaveProperty('string');
+    expectTypeOf<Result>().toHaveProperty('number');
+    expectTypeOf<Result>().toHaveProperty('boolean');
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+
+    // Should NOT have unselected properties
+    expectTypeOf<Result>().not.toHaveProperty('object');
+    expectTypeOf<Result>().not.toHaveProperty('array');
+    expectTypeOf<Result>().not.toHaveProperty('map');
+    expectTypeOf<Result>().not.toHaveProperty('set');
+    expectTypeOf<Result>().not.toHaveProperty('binary');
+    expectTypeOf<Result>().not.toHaveProperty('GSI_1_PK');
+  });
+
+  test('Should work with all properties selected', () => {
+    type Result = EntitySelectedAttributes<typeof User, ['id', 'name', 'email', 'age', 'address']>;
+
+    expectTypeOf<Result>().toHaveProperty('id');
+    expectTypeOf<Result>().toHaveProperty('name');
+    expectTypeOf<Result>().toHaveProperty('email');
+    expectTypeOf<Result>().toHaveProperty('age');
+    expectTypeOf<Result>().toHaveProperty('address');
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+  });
+
+  test('Should narrow nested object paths correctly', () => {
+    type Result = EntitySelectedAttributes<typeof MockEntity, ['object', 'object.optional', 'object.required']>;
+
+    expectTypeOf<Result>().toHaveProperty('object');
+    expectTypeOf<Result>().toHaveProperty('dynamodeEntity');
+
+    expectTypeOf<Result>().not.toHaveProperty('string');
+    expectTypeOf<Result>().not.toHaveProperty('number');
+    expectTypeOf<Result>().not.toHaveProperty('array');
+  });
+
+  test('Should work with different attribute types', () => {
+    type StringOnly = EntitySelectedAttributes<typeof User, ['name']>;
+    expectTypeOf<StringOnly>().toMatchTypeOf<{ name: string; dynamodeEntity: string }>();
+
+    type NumberOnly = EntitySelectedAttributes<typeof User, ['age']>;
+    expectTypeOf<NumberOnly>().toMatchTypeOf<{ age: number; dynamodeEntity: string }>();
+
+    type Mixed = EntitySelectedAttributes<typeof User, ['name', 'age']>;
+    expectTypeOf<Mixed>().toMatchTypeOf<{ name: string; age: number; dynamodeEntity: string }>();
+  });
+
+  test('Should maintain instance type structure', () => {
+    type Result = EntitySelectedAttributes<typeof User, ['id', 'name']>;
+
+    // Result should still be an object type
+    expectTypeOf<Result>().toBeObject();
+
+    // Should not be the full User instance
+    expectTypeOf<Result>().not.toEqualTypeOf<InstanceType<typeof User>>();
+
+    // But should be assignable from a partial User with selected fields
+    type Partial = Pick<InstanceType<typeof User>, 'id' | 'name' | 'dynamodeEntity'>;
+    expectTypeOf<Result>().toMatchTypeOf<Partial>();
+  });
+});

--- a/tests/unit/entity/helpers/converters.test.ts
+++ b/tests/unit/entity/helpers/converters.test.ts
@@ -11,7 +11,13 @@ import {
 } from '@lib/entity/helpers/converters';
 import * as transformValuesHelpers from '@lib/entity/helpers/transformValues';
 
-import { mockDate, MockEntity, mockInstance, TestTableMetadata } from '../../../fixtures/TestTable';
+import {
+  mockDate,
+  MockEntity,
+  mockInstance,
+  partialMockInstance,
+  TestTableMetadata,
+} from '../../../fixtures/TestTable';
 
 const metadata = {
   tableName: 'test-table',
@@ -92,6 +98,16 @@ const mockEntityAttributes = {
     propertyName: 'binary',
     type: Uint8Array,
   },
+  numDate: {
+    propertyName: 'numDate',
+    type: Number,
+    role: 'date',
+  },
+  strDate: {
+    propertyName: 'strDate',
+    type: String,
+    role: 'date',
+  },
 } as any as AttributesMetadata;
 
 const dynamoObject = {
@@ -107,6 +123,13 @@ const dynamoObject = {
   array: { L: [{ S: '1' }, { S: '2' }] },
   boolean: { BOOL: true },
   binary: { B: new Uint8Array([1, 2, 3]) },
+  strDate: { S: mockDate.toISOString() },
+  numDate: { N: mockDate.getTime().toString() },
+};
+
+const partialDynamoObject = {
+  string: { S: 'string' },
+  map: { M: { '1': { S: '2' } } },
 };
 
 describe('Converters entity helpers', () => {
@@ -141,15 +164,17 @@ describe('Converters entity helpers', () => {
       getEntityMetadataSpy.mockReturnValue(metadata as any);
 
       expect(convertAttributeValuesToEntity(MockEntity, dynamoObject)).toEqual(mockInstance);
-      expect(truncateValueSpy).toBeCalledTimes(16);
+      expect(truncateValueSpy).toBeCalledTimes(18);
     });
 
     test('Should return object in dynamode format', async () => {
       getEntityAttributesSpy.mockReturnValue(mockEntityAttributes);
       getEntityMetadataSpy.mockReturnValue(metadata as any);
 
-      expect(convertAttributeValuesToEntity(MockEntity, dynamoObject)).toEqual(mockInstance);
-      expect(truncateValueSpy).toBeCalledTimes(16);
+      expect(convertAttributeValuesToEntity(MockEntity, partialDynamoObject, ['map', 'string'])).toEqual(
+        partialMockInstance,
+      );
+      expect(truncateValueSpy).toBeCalledTimes(18);
     });
   });
 

--- a/tests/unit/entity/index.test.ts
+++ b/tests/unit/entity/index.test.ts
@@ -167,7 +167,7 @@ describe('entityManager', () => {
         Key: primaryKey,
         ConsistentRead: false,
       });
-      expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, mockInstance);
+      expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, mockInstance, undefined);
     });
 
     test("Should throw an error if item wasn't found", async () => {
@@ -928,8 +928,8 @@ describe('entityManager', () => {
         },
       });
       expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(2);
-      expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, mockInstance);
-      expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, testTableInstance);
+      expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, mockInstance, undefined);
+      expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, testTableInstance, undefined);
     });
 
     test('Should return dynamode result (one item found)', async () => {
@@ -958,7 +958,7 @@ describe('entityManager', () => {
         },
       });
       expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(1);
-      expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, mockInstance);
+      expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, mockInstance, undefined);
     });
 
     test('Should return dynamode result with unprocessed keys', async () => {

--- a/tests/unit/query/index.test.ts
+++ b/tests/unit/query/index.test.ts
@@ -250,7 +250,7 @@ describe('Query', () => {
 
         expect(timeoutSpy).not.toBeCalled();
         expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(1);
-        expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, { key: 'value' });
+        expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, { key: 'value' }, []);
         expect(convertAttributeValuesToLastKeySpy).toBeCalledTimes(1);
         expect(convertAttributeValuesToLastKeySpy).toBeCalledWith(MockEntity, {
           partitionKey: 'lastValue',
@@ -281,9 +281,9 @@ describe('Query', () => {
 
         expect(timeoutSpy).toBeCalledTimes(3);
         expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(3);
-        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, { key: 'value1' });
-        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, { key: 'value2' });
-        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(3, MockEntity, { key: 'value3' });
+        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, { key: 'value1' }, []);
+        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, { key: 'value2' }, []);
+        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(3, MockEntity, { key: 'value3' }, []);
         expect(convertAttributeValuesToLastKeySpy).not.toBeCalled();
       });
 
@@ -309,8 +309,8 @@ describe('Query', () => {
 
         expect(timeoutSpy).toBeCalledTimes(2);
         expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(2);
-        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, { key: 'value1' });
-        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, { key: 'value2' });
+        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(1, MockEntity, { key: 'value1' }, []);
+        expect(convertAttributeValuesToEntitySpy).toHaveBeenNthCalledWith(2, MockEntity, { key: 'value2' }, []);
         expect(convertAttributeValuesToLastKeySpy).toBeCalledTimes(1);
         expect(convertAttributeValuesToLastKeySpy).toBeCalledWith(MockEntity, { key: 'value2' });
       });

--- a/tests/unit/scan/index.test.ts
+++ b/tests/unit/scan/index.test.ts
@@ -139,7 +139,7 @@ describe('Scan', () => {
       });
 
       expect(convertAttributeValuesToEntitySpy).toBeCalledTimes(1);
-      expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, { key: 'value' });
+      expect(convertAttributeValuesToEntitySpy).toBeCalledWith(MockEntity, { key: 'value' }, []);
       expect(convertAttributeValuesToLastKeySpy).toBeCalledTimes(1);
       expect(convertAttributeValuesToLastKeySpy).toBeCalledWith(MockEntity, {
         partitionKey: 'lastValue',


### PR DESCRIPTION
### Summary:

Fixes a bug where calling `.get()` with a specified `attributes` array incorrectly overrides other non-requested fields in the returned item with default constructor values, instead of preserving the true values from DynamoDB.

This causes retrieved entities to differ from their actual stored state when partial attribute projections are used.

### Code sample:

#### Model

```ts
import { attribute, Dynamode, Entity, TableManager } from "dynamode";

Dynamode.ddb.local();

export class User extends Entity {
    @attribute.partitionKey.string()
    email: string;

    @attribute.string()
    name: string;

    @attribute.boolean()
    isAdmin: boolean;

    @attribute.date.string()
    createdAt: Date;

    constructor(props: { email: string, name: string, isAdmin?: boolean, createdAt?: Date }) {
        super();
        this.email = props.email;
        this.name = props.name;
        this.isAdmin = props.isAdmin || false;
        this.createdAt = props.createdAt || new Date();
    }
}

const UserTableManager = new TableManager(User, {
    tableName: "Users",
    partitionKey: "email",
    createdAt: "createdAt"
});

export const UserManager = UserTableManager.entityManager();

try { await UserTableManager.createTable() } catch { } // created already
```

#### General

```ts
await UserManager.create(new User({ email: "user1@example.com", name: "User 1" }));
await UserManager.update(
  { email: "user1@example.com" },
  { set: { createdAt: new Date("2000-01-01T12:00:00Z"), isAdmin: true } }
);

// ❌ Incorrect behavior
const user1 = await UserManager.get({ email: "user1@example.com" }, { attributes: ["name"] });
console.log(user1.isAdmin);   // should be undefined
console.log(user1.createdAt); // should be undefined

// ✅ Correct behavior
const user2 = await UserManager.get({ email: "user1@example.com" });
console.log(user2.isAdmin);   // returns true as expected
console.log(user2.createdAt); // returns correct DB value
```

### GitHub linked issue:

https://github.com/blazejkustra/dynamode/issues/44

### Type of change:

* [x] Bug fix
* [ ] Feature implementation
* [ ] Documentation improvement
* [ ] Testing improvement
* [ ] Something not listed here

### Is this a breaking change?

* [x] Partly yes
* [ ] No

### Other:

* [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
* [ ] I have updated the Dynamode documentation (if required)
* [x] I have added/updated the Dynamode test cases (if required)
* [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [[Dynamode License](https://chatgpt.com/LICENSE)](../LICENSE).
